### PR TITLE
Fix BMI calculator line break

### DIFF
--- a/calculator.html
+++ b/calculator.html
@@ -104,7 +104,6 @@
       const bmi = calculateBMI(w, h);
       const bmr = calculateBMR(w, h, a, g);
       const calories = estimateCalories(bmr);
-
       const text = `BMI: ${bmi.toFixed(2)} | BMR: ${bmr.toFixed(0)} | Daily Calories: ${calories.toFixed(0)}`;
       document.getElementById('results').textContent = text;
     });


### PR DESCRIPTION
## Summary
- fix stray newline before BMI results string in `calculator.html`

## Testing
- `npm install jsdom` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687dee468360832e9c84c43ff1808c47