### PR TITLE
Add basic Node tests for calculator

### DIFF
--- a/fitness-calc.js
+++ b/fitness-calc.js
@@ -13,3 +13,12 @@ function calculateBMR(weight, height, age, gender) {
 function estimateCalories(bmr, activity = 1.55) {
   return bmr * activity;
 }
+
+// Export functions when running in Node.js
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = {
+    calculateBMI,
+    calculateBMR,
+    estimateCalories,
+  };
+}

--- a/tests/fitness-calc.test.js
+++ b/tests/fitness-calc.test.js
@@ -1,0 +1,27 @@
+const assert = require('assert');
+const { calculateBMI, calculateBMR, estimateCalories } = require('../fitness-calc.js');
+
+function nearlyEqual(actual, expected, delta = 0.001) {
+  assert.ok(Math.abs(actual - expected) <= delta,
+    `${actual} not within ${delta} of ${expected}`);
+}
+
+// Typical input values
+const weight = 70;    // kg
+const height = 170;   // cm
+const age = 30;       // years
+const gender = 'male';
+
+const bmiExpected = weight / ((height / 100) ** 2);
+const bmi = calculateBMI(weight, height);
+nearlyEqual(bmi, bmiExpected);
+
+const bmrExpected = 10 * weight + 6.25 * height - 5 * age + 5;
+const bmr = calculateBMR(weight, height, age, gender);
+nearlyEqual(bmr, bmrExpected);
+
+const caloriesExpected = bmrExpected * 1.55;
+const calories = estimateCalories(bmr, 1.55);
+nearlyEqual(calories, caloriesExpected);
+
+console.log('All tests passed!');


### PR DESCRIPTION
## Summary
- expose fitness-calculator functions for Node
- add minimal Node-based test using `assert`

## Testing
- `node tests/fitness-calc.test.js`


------
https://chatgpt.com/codex/tasks/task_e_687df30a70c8832e9e98734851f1e45b